### PR TITLE
Create Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org' do
+  gem 'colorize'
+  gem 'shodan'
+  gem 'rest-client'
+  gem 'nokogiri'
+end


### PR DESCRIPTION
Ruby dependency management is better handled using a Gemfile; you can tie to specific gem version which is useful when your tool was built against an earlier version and upstream release a new major and break it.
("gem install" by default will always install the latest version)

next in setup.rb you can run "gem install -g" rather than all the multiple gem invocations via the shell